### PR TITLE
Make image2image faster by broadcasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [PYTHON] Lego generator
 
+**New Idea**: Duplicate the lego piece and directly add it to the image, it will remove all the ugly part in spliting the image into piece like the original impl. I'll try it tomorrow
+
 ## Introduction
 
 Here is my python source code for Lego generator. To the best of my knowledge, my code is the shortest one you could find out for this goal. With my code, you could: 


### PR DESCRIPTION
Thanks for your nice repo, the idea and your code base is really friendly and easy to understand.
This pull request slightly improve the speed of your `lego-nization` algorithm by replacing `for loop` with `broadcasting`.
Run benchmark on my Air M1 show that the speed is nearly ~3X faster on `input.jpg`
The output image is nearly identical (because of rounding number, it's < 1% different)

<img width="969" alt="Screen Shot 2021-05-11 at 17 23 47" src="https://user-images.githubusercontent.com/17178612/117800740-a7c08400-b27d-11eb-9f15-25a4fb1e0546.png">

